### PR TITLE
Update workflows to skip builds on main branch pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build on push
 
 on:
   push:
+    branches-ignore:
+      - main
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Résumé du scénario demandé
 🔁 Sur chaque push
 
-    ✅ Build + Test
+    ✅ Build + Test (sauf main car job fait par un autre workflow)
 
 🔀 Sur chaque PR mergée vers main
 


### PR DESCRIPTION
Adjusted the README to reflect that main branch builds are managed by another workflow. Updated `build.yml` to ignore pushes to the main branch for efficiency.